### PR TITLE
メニューシャッフル機能でのスライダー機能の追加

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,7 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("semantic-ui-sass")
+// require ('packs/slick_slider.js')
 // require("packs/preview.js")
 // require("packs/preview_menus.js")
 

--- a/app/javascript/packs/slick_slider.js
+++ b/app/javascript/packs/slick_slider.js
@@ -1,0 +1,14 @@
+// document.addEventListener("turbolinks:load", function(){
+//   $('.slider').slick({
+//       arrows: true,
+//       prevArrow:'<i class="angle left big icon"></i>',
+//       nextArrow:'<i class="angle right big icon"></i>',
+//       dots: true,
+//       autoplay: true,
+//       autoplaySpeed: 4000,
+//       speed: 800
+//   });
+//   $('.slick-dots li').on('mouseover', function() {
+//     $('.slider').slick('goTo', $(this).index());
+//   });
+// });

--- a/app/views/shared/_decide_menu.html.haml
+++ b/app/views/shared/_decide_menu.html.haml
@@ -1,28 +1,18 @@
 = render "shared/header"
-.ui.text.container.center.aligned.grid{style: "margin-top: 20px;"}
-  %h1.ui.header= "#{@random_menu.name}にしましょう"
 .ui.container
+  .ui.grid{style: "margin-top: 10px;"}
+    .column
+      .ui.huge.massive.grey.tag.label
+        = @random_menu.name + "にしましょう"
   .ui.stackable.two.column.grid{style: "margin-top: 30px;"}
-    .center.aligned.column
-      .ui.shape
-        .sides
-          .active.side
-            .ui.centered.card
-              .image
-                = image_tag @random_menu.menu_images[0].image.url, style: "height: 280px"
+    .column
+      .previews
+        .slider
+          = image_tag @random_menu.menu_images[0].image.url
           - if @random_menu.menu_images[1].present?
             - @random_menu.menu_images.each_with_index do |i, index|
               - next if index == 0
-              .side
-                .ui.centered.card
-                  .image
-                    = image_tag @random_menu.menu_images[index].image.url, style: "height: 280px"
-      %h1
-      .ui.container.two.buttons
-        .ui.button{id: "left-btn"}
-          %i.left.long.arrow.icon
-        .ui.button{id: "right-btn"}
-          %i.right.long.arrow.icon
+              = image_tag @random_menu.menu_images[index].image.url
     .column
       - if @random_menu.genre.present?
         .ui.dividing.header ジャンル
@@ -35,3 +25,41 @@
         %p= @random_menu.text
   .ui.text.container.center.aligned.grid{style: "margin-top: 40px;"}
     = link_to "この気分じゃない", random_menu_decide_menus_path, class: "fluid ui orange big button", style: "margin-bottom: 40px;"
+
+-# = javascript_pack_tag 'slick_slider.js'
+
+:javascript
+  $(function() {
+    $('.slider').slick({
+        arrows: true,
+        prevArrow:'<i class="angle left big icon"></i>',
+        nextArrow:'<i class="angle right big icon"></i>',
+        dots: true,
+        autoplay: true,
+        autoplaySpeed: 4000,
+        speed: 800
+    });
+
+    $('.slick-dots li').on('mouseover', function() {
+      $('.slider').slick('goTo', $(this).index());
+    });
+  });
+
+:css
+  .slider img {
+      width: 100%;
+      height: 50vh; /* 画像の高さ指定 */
+      object-fit: cover;
+  }
+  .slick-arrow {
+    position: absolute;
+    top: 25vh; /* 画像の高さの半分＝画像の真ん中に配置 */
+    margin: auto;
+  }
+  .left {
+    left: 0;
+    z-index: 10;
+  }
+  .right {
+    right: 0;
+  }


### PR DESCRIPTION
## 何をしたのか
- メニューシャッフル機能でのslicksliderの追加
## なぜ行ったのか
- show画面との統一感を出すため
## どのように行ったか
- menu > show.html.hamlでのスライダー機能をそのまま使った
- JSがまとめ切れていないところは、後にwebpackでの修正が必要（画像プレビューしかり）