### PR TITLE
slick sliderのjQueryを別ファイルにまとめた

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,7 +9,7 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("semantic-ui-sass")
-// require ('packs/slick_slider.js')
+require ('packs/slick_slider.js')
 // require("packs/preview.js")
 // require("packs/preview_menus.js")
 

--- a/app/javascript/packs/slick_slider.js
+++ b/app/javascript/packs/slick_slider.js
@@ -1,14 +1,14 @@
-// document.addEventListener("turbolinks:load", function(){
-//   $('.slider').slick({
-//       arrows: true,
-//       prevArrow:'<i class="angle left big icon"></i>',
-//       nextArrow:'<i class="angle right big icon"></i>',
-//       dots: true,
-//       autoplay: true,
-//       autoplaySpeed: 4000,
-//       speed: 800
-//   });
-//   $('.slick-dots li').on('mouseover', function() {
-//     $('.slider').slick('goTo', $(this).index());
-//   });
-// });
+document.addEventListener("turbolinks:load", function(){
+  $('.slider').slick({
+      arrows: true,
+      prevArrow:'<i class="angle left big icon"></i>',
+      nextArrow:'<i class="angle right big icon"></i>',
+      dots: true,
+      autoplay: true,
+      autoplaySpeed: 4000,
+      speed: 800
+  });
+  $('.slick-dots li').on('mouseover', function() {
+    $('.slider').slick('goTo', $(this).index());
+  });
+});

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,7 +9,6 @@
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     %link{href: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css", rel: "stylesheet", type: "text/css"}/
     %link{href: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css", rel: "stylesheet", type: "text/css"}/
-    %script{src: "http://code.jquery.com/jquery-1.11.0.min.js", type: "text/javascript"}
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
     %script{src: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js", type: "text/javascript"}
   %body

--- a/app/views/menus/new.html.haml
+++ b/app/views/menus/new.html.haml
@@ -76,14 +76,9 @@
   // 画像削除
   function deleteImg(event, targetId){
     let previewImage = document.getElementById("preview-img"+targetId);
-    // input file の中身を削除
-    // let file = document.getElementById("preview-file"+targetId);
-    // file.value = "";
-
     // inputを削除し、新たなinput要素を追加する
     let delete_input = document.getElementById("delete_input" + targetId);
     delete_input.innerHTML = '';
-    // delete_input.remove();
     // 新たにinput要素追加
     let nullInput = `
                       <input type="file" class="preview-file" id="preview-file${targetId}" style="display: none;" onchange="addImg(event, ${targetId})" name="menu[menu_images_attributes][${targetId}][image]">

--- a/app/views/menus/show.html.haml
+++ b/app/views/menus/show.html.haml
@@ -29,23 +29,6 @@
           .ui.dividing.header メモ
           %p= @menu.text
 
-:javascript
-  $(function() {
-    $('.slider').slick({
-        arrows: true,
-        prevArrow:'<i class="angle left big icon"></i>',
-        nextArrow:'<i class="angle right big icon"></i>',
-        dots: true,
-        autoplay: true,
-        autoplaySpeed: 4000,
-        speed: 800
-    });
-
-    $('.slick-dots li').on('mouseover', function() {
-      $('.slider').slick('goTo', $(this).index());
-    });
-  });
-
 :css
   .slider img {
       width: 100%;

--- a/app/views/shared/_decide_menu.html.haml
+++ b/app/views/shared/_decide_menu.html.haml
@@ -26,25 +26,6 @@
   .ui.text.container.center.aligned.grid{style: "margin-top: 40px;"}
     = link_to "この気分じゃない", random_menu_decide_menus_path, class: "fluid ui orange big button", style: "margin-bottom: 40px;"
 
--# = javascript_pack_tag 'slick_slider.js'
-
-:javascript
-  $(function() {
-    $('.slider').slick({
-        arrows: true,
-        prevArrow:'<i class="angle left big icon"></i>',
-        nextArrow:'<i class="angle right big icon"></i>',
-        dots: true,
-        autoplay: true,
-        autoplaySpeed: 4000,
-        speed: 800
-    });
-
-    $('.slick-dots li').on('mouseover', function() {
-      $('.slider').slick('goTo', $(this).index());
-    });
-  });
-
 :css
   .slider img {
       width: 100%;

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -3,9 +3,8 @@ const { environment } = require('@rails/webpacker')
 var webpack = require('webpack');
 
 environment.plugins.append("Provide", new webpack.ProvidePlugin({
-  $: 'jquery',
-  jQuery: 'jquery',
-  Popper: ['popper.js', 'default']
+  $: 'jquery/src/jquery',
+  jQuery: 'jquery/src/jquery'
 }))
 
 module.exports = environment


### PR DESCRIPTION
## 何を行ったか
- slick sliderのjQueryを別ファイルにまとめた
## なぜ行ったか
- フロントとJSのファイルを分けていなく、コードをのちに修正しやすく見やすいように分けたかった。
- 元々は、プレビュー機能のJSも分けたかったが、イベントハンドラが外部ファイルで起動しないため、後に修正。
## どのように行った
- slick_slider.jsファイルの作成。
