### PR TITLE
ユーザーメールアドレス・パスワード編集機能のバグ回収

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -9,7 +9,7 @@
       %i.dropdown.icon
       .menu
         = link_to "ユーザー情報編集", edit_user_path(current_user.id), class: "item"
-        = link_to "メールアドレス・パスワード変更", edit_user_registration_path, class: "item"
+        = link_to "メールアドレス・パスワード変更", edit_user_password_path, class: "item"
         = link_to "ログアウト", destroy_user_session_path, method: :delete, class: "item"
     = link_to "一覧", menus_path, class: "item"
     = link_to "決める", decide_menus_path,class: "item"

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -9,7 +9,7 @@
       %i.dropdown.icon
       .menu
         = link_to "ユーザー情報編集", edit_user_path(current_user.id), class: "item"
-        = link_to "メールアドレス・パスワード変更", edit_user_password_path, class: "item"
+        = link_to "メールアドレス・パスワード変更", edit_user_registration_path, class: "item"
         = link_to "ログアウト", destroy_user_session_path, method: :delete, class: "item"
     = link_to "一覧", menus_path, class: "item"
     = link_to "決める", decide_menus_path,class: "item"

--- a/app/views/users/registrations/edit.html.haml
+++ b/app/views/users/registrations/edit.html.haml
@@ -33,4 +33,4 @@
         .actions
           = f.submit "更新", class: "ui primary button", style: "margin-bottom: 30px;"
           = render "users/shared/error_messages", resource: resource
-          = button_to "アカウント削除", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "ui red basic button", style: "margin-top: 100px;"
+      = button_to "アカウント削除", registration_path(resource_name), data: { confirm: "本当にユーザーを削除しますか？" }, method: :delete, class: "ui red basic button", style: "margin-top: 100px;"


### PR DESCRIPTION
## 何を行ったか
- ユーザーのメールアドレスとパスワードの編集を行うとアカウントの削除が発生してしまうので、更新できるように変更。
## なぜ行ったのか
- ユーザーが意図しない機能であるため。
## どのように行ったのか
- formタグの中のbotton_toが更新するボタンであるf.submitの機能を削除するよう影響を与えていたため、button_toをformタグの外に移動し、機能を改善
- 削除確認を「Are you sure?」から「本当にユーザーを削除しますか？」に変更。