### PR TITLE
メニューを選択した日付を記憶する機能のモデル・コントローラー作成

### DIFF
--- a/app/assets/stylesheets/menu_histories.scss
+++ b/app/assets/stylesheets/menu_histories.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the menu_histories controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/menu_histories_controller.rb
+++ b/app/controllers/menu_histories_controller.rb
@@ -1,0 +1,20 @@
+class MenuHistoriesController < ApplicationController
+  def index
+  end
+
+  def show
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def delete
+  end
+
+end

--- a/app/helpers/menu_histories_helper.rb
+++ b/app/helpers/menu_histories_helper.rb
@@ -1,0 +1,2 @@
+module MenuHistoriesHelper
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -2,6 +2,7 @@ class Menu < ApplicationRecord
   has_many :menu_images, dependent: :destroy
   accepts_nested_attributes_for :menu_images, allow_destroy: true
   belongs_to :user
+  belongs_to :menu_history
   validates :name, presence: true
   validates :menu_images, presence: true
 end

--- a/app/models/menu_history.rb
+++ b/app/models/menu_history.rb
@@ -1,2 +1,3 @@
 class MenuHistory < ApplicationRecord
+  has_many :menus
 end

--- a/app/models/menu_history.rb
+++ b/app/models/menu_history.rb
@@ -1,0 +1,2 @@
+class MenuHistory < ApplicationRecord
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,5 +11,7 @@
     %link{href: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css", rel: "stylesheet", type: "text/css"}/
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
     %script{src: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js", type: "text/javascript"}
+    %script{src: "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui-calendar/0.0.8/calendar.min.js", type: "text/javascript"}
+    %link{href: "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui-calendar/0.0.8/calendar.min.css", rel: "stylesheet", type: "text/css"}/
   %body
     = yield

--- a/app/views/menu_histories/edit.html.haml
+++ b/app/views/menu_histories/edit.html.haml
@@ -1,0 +1,2 @@
+%h1 MenuHistories#edit
+%p Find me in app/views/menu_histories/edit.html.haml

--- a/app/views/menu_histories/index.html.haml
+++ b/app/views/menu_histories/index.html.haml
@@ -1,0 +1,2 @@
+%h1 MenuHistories#index
+%p Find me in app/views/menu_histories/index.html.haml

--- a/app/views/menu_histories/index.html.haml
+++ b/app/views/menu_histories/index.html.haml
@@ -1,2 +1,20 @@
-%h1 MenuHistories#index
-%p Find me in app/views/menu_histories/index.html.haml
+= render "shared/header"
+.field.ui.calendar.required
+  %lavel
+    = "日付"
+  .ui.input.left.icon
+    %i.calendar.icon
+    %input{type: "text", name: "date", placeholder: "日付"}
+
+:javascript
+  $('.ui.calendar').calendar({
+    type: 'date',
+    formatter: {
+      date: function (date) {
+        var day = ('0' + date.getDate()).slice(-2);
+        var month = ('0' + (date.getMonth() + 1)).slice(-2);
+        var year = date.getFullYear();
+        return year + '/' + month + '/' + day;
+      }
+    }
+  });

--- a/app/views/menu_histories/show.html.haml
+++ b/app/views/menu_histories/show.html.haml
@@ -1,0 +1,2 @@
+%h1 MenuHistories#show
+%p Find me in app/views/menu_histories/show.html.haml

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -13,6 +13,7 @@
         = link_to "ログアウト", destroy_user_session_path, method: :delete, class: "item"
     = link_to "一覧", menus_path, class: "item"
     = link_to "決める", decide_menus_path,class: "item"
+    = link_to "履歴", menu_histories_path,class: "item"
     .right.menu
       .item{style: "width: 35vw;"}
         = search_form_for @q, html: { class: "ui transparent icon input" }, url: menu_search_menus_path do |f|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
       get :menu_search
     end
   end
+  resources :menu_histories, only: [:index, :show, :create, :edit, :update, :delete]
   resources :decide_menus do
     collection do
       get :staple_food_menu

--- a/db/migrate/20210125112151_create_menu_histories.rb
+++ b/db/migrate/20210125112151_create_menu_histories.rb
@@ -1,7 +1,8 @@
 class CreateMenuHistories < ActiveRecord::Migration[6.0]
   def change
     create_table :menu_histories do |t|
-
+      t.references :menu, foreign_key: true
+      t.timestamp :eating_date
       t.timestamps
     end
   end

--- a/db/migrate/20210125112151_create_menu_histories.rb
+++ b/db/migrate/20210125112151_create_menu_histories.rb
@@ -1,0 +1,8 @@
+class CreateMenuHistories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :menu_histories do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_30_093833) do
+ActiveRecord::Schema.define(version: 2021_01_25_112151) do
+
+  create_table "menu_histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "menu_id"
+    t.timestamp "eating_date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["menu_id"], name: "index_menu_histories_on_menu_id"
+  end
 
   create_table "menu_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "menu_id"
@@ -46,6 +54,7 @@ ActiveRecord::Schema.define(version: 2020_10_30_093833) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "menu_histories", "menus"
   add_foreign_key "menu_images", "menus"
   add_foreign_key "menus", "users"
 end

--- a/test/controllers/menu_histories_controller_test.rb
+++ b/test/controllers/menu_histories_controller_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class MenuHistoriesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get menu_histories_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get menu_histories_show_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get menu_histories_edit_url
+    assert_response :success
+  end
+
+  test "should get delete" do
+    get menu_histories_delete_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get menu_histories_create_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/menu_histories.yml
+++ b/test/fixtures/menu_histories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/menu_history_test.rb
+++ b/test/models/menu_history_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MenuHistoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 何を行ったか
- メニューを選択した日付を記憶する機能のモデル・コントローラー作成
## なぜ行ったのか
- 過去1ヶ月間の献立を表示しないように献立を決めるメニューの作成をしたかったため。何回も同じメニューが出てくることを防ぎたいため。
- この機能2時間がかかりそうなので、ブランチを分ける
## どのように行ったか
- 新しくデータベースにmenu_historyテーブルを作成し、そこに履歴情報を記載できるようにしている
- 履歴を一覧できるページ遷移まで完了
- menu_history.index.hamlには現在、semantic uiのカレンダー機能を搭載