### PR TITLE
メニュー作成履歴バックエンド処理実施

### DIFF
--- a/app/controllers/decide_menus_controller.rb
+++ b/app/controllers/decide_menus_controller.rb
@@ -1,14 +1,15 @@
 class DecideMenusController < ApplicationController
 
   def index
-    @random_menu_id = current_user.menus.order("RAND()").first
-    @staple_food_menu_id = current_user.menus.where(genre: '主食').order("RAND()").first
-    @main_dish_menu_id = current_user.menus.where(genre: '主菜').order("RAND()").first
-    @vegetable_menu_id = current_user.menus.where(genre: '野菜').order("RAND()").first
-    @one_item_menu_id = current_user.menus.where(genre: '一品もの').order("RAND()").first
-    @dessert_menu_id = current_user.menus.where(genre: 'デザート').order("RAND()").first
-    @other_menu_id = current_user.menus.where(genre: 'その他').order("RAND()").first
-    @eating_out_menu_id = current_user.menus.where(genre: '外食').order("RAND()").first
+    @random_menu = current_user.menus.order("RAND()").first
+    @staple_food_menu = current_user.menus.where(genre: '主食').order("RAND()").first
+    @main_dish_menu = current_user.menus.where(genre: '主菜').order("RAND()").first
+    @vegetable_menu = current_user.menus.where(genre: '野菜').order("RAND()").first
+    @one_item_menu = current_user.menus.where(genre: '一品もの').order("RAND()").first
+    @dessert_menu = current_user.menus.where(genre: 'デザート').order("RAND()").first
+    @other_menu = current_user.menus.where(genre: 'その他').order("RAND()").first
+    @eating_out_menu = current_user.menus.where(genre: '外食').order("RAND()").first
+    @decide_menus = [@random_menu, @staple_food_menu, @main_dish_menu, @vegetable_menu, @main_dish_menu, @vegetable_menu, @one_item_menu, @dessert_menu, @other_menu, @eating_out_menu]
   end
 
   def random_menu(genre = "")

--- a/app/controllers/decide_menus_controller.rb
+++ b/app/controllers/decide_menus_controller.rb
@@ -12,14 +12,14 @@ class DecideMenusController < ApplicationController
     @decide_menus = [@random_menu, @staple_food_menu, @main_dish_menu, @vegetable_menu, @main_dish_menu, @vegetable_menu, @one_item_menu, @dessert_menu, @other_menu, @eating_out_menu]
   end
 
-  def random_menu(genre = "")
+  def random_menu
     @random_menu = current_user.menus.find(params[:id])
-    if genre == ""
-      @next_random_menu_id = current_user.menus.order("RAND()").first
-    else
-      @next_random_menu_id = current_user.menus.where(genre: genre).order("RAND()").first
+    # if genre == ""
+    #   @next_random_menu = current_user.menus.order("RAND()").first
+    # else
+    #   @next_random_menu = current_user.menus.where(genre: genre).order("RAND()").first
     end
-    if judge_extence_junre_menus(genre, @random_menu) == false
+    if judge_extence_junre_menus(genre, @random_menu) == false # ジャンルのメニューが無い場合
       redirect_to decide_menus_path
     end
   end

--- a/app/controllers/decide_menus_controller.rb
+++ b/app/controllers/decide_menus_controller.rb
@@ -11,18 +11,23 @@ class DecideMenusController < ApplicationController
     @eating_out_menu_id = current_user.menus.where(genre: '外食').order("RAND()").first
   end
 
-  def random_menu(jenre = "")
+  def random_menu(genre = "")
     @random_menu = current_user.menus.find(params[:id])
-    if judge_extence_junre_menus(jenre, @random_menu) == false
+    if genre == ""
+      @next_random_menu_id = current_user.menus.order("RAND()").first
+    else
+      @next_random_menu_id = current_user.menus.where(genre: genre).order("RAND()").first
+    end
+    if judge_extence_junre_menus(genre, @random_menu) == false
       redirect_to decide_menus_path
     end
   end
 
-  def judge_extence_junre_menus(jenre, random_menu)
+  def judge_extence_junre_menus(genre, random_menu)
     if random_menu.blank? && jenre != ""
-      flash[:alert] = "#{jenre}は登録されていません"
+      flash[:alert] = "#{genre}は登録されていません"
       return false
-    elsif random_menu.blank? && jenre == ""
+    elsif random_menu.blank? && genre == ""
       flash[:alert] = "ジャンルがあるメニューを登録してください"
       return false
     else

--- a/app/controllers/decide_menus_controller.rb
+++ b/app/controllers/decide_menus_controller.rb
@@ -11,9 +11,9 @@ class DecideMenusController < ApplicationController
     @eating_out_menu_id = current_user.menus.where(genre: '外食').order("RAND()").first
   end
 
-  def random_menu(jenre)
+  def random_menu(jenre = "")
     @random_menu = current_user.menus.find(params[:id])
-    if judge_extence_junre_menus(jenre, @random_menu) == false
+    if judge_extence_junre_menus(jenre, @random_menu)
       redirect_to decide_menus_path
     end
   end

--- a/app/controllers/decide_menus_controller.rb
+++ b/app/controllers/decide_menus_controller.rb
@@ -16,41 +16,6 @@ class DecideMenusController < ApplicationController
     judge_extence_junre_menus("", @random_menu)
   end
 
-  def staple_food_menu
-    @random_menu = current_user.menus.where(genre: '主食').order("RAND()").first
-    judge_extence_junre_menus("主食", @random_menu)
-  end
-
-  def main_dish_menu
-    @random_menu = current_user.menus.where(genre: '主菜').order("RAND()").first
-    judge_extence_junre_menus("主菜", @random_menu)
-  end
-
-  def vegetable_menu
-    @random_menu = current_user.menus.where(genre: '野菜').order("RAND()").first
-    judge_extence_junre_menus("野菜", @random_menu)
-  end
-
-  def one_item_menu
-    @random_menu = current_user.menus.where(genre: '一品もの').order("RAND()").first
-    judge_extence_junre_menus("一品もの", @random_menu)
-  end
-
-  def dessert_menu
-    @random_menu = current_user.menus.where(genre: 'デザート').order("RAND()").first
-    judge_extence_junre_menus("デザート", @random_menu)
-  end
-
-  def other_menu
-    @random_menu = current_user.menus.where(genre: 'その他').order("RAND()").first
-    judge_extence_junre_menus("その他", @random_menu)
-  end
-
-  def eating_out
-    @random_menu = current_user.menus.where(genre: '外食').order("RAND()").first
-    judge_extence_junre_menus("外食", @random_menu)
-  end
-
   def judge_extence_junre_menus(jenre, random_menu)
     puts random_menu
     if random_menu.blank? && jenre != ""

--- a/app/controllers/decide_menus_controller.rb
+++ b/app/controllers/decide_menus_controller.rb
@@ -12,7 +12,7 @@ class DecideMenusController < ApplicationController
   end
 
   def random_menu
-    @random_menu = current_user.menus.order("RAND()").first
+    @random_menu = current_user.menus.find(params[:id])
     judge_extence_junre_menus("", @random_menu)
   end
 

--- a/app/controllers/decide_menus_controller.rb
+++ b/app/controllers/decide_menus_controller.rb
@@ -13,7 +13,7 @@ class DecideMenusController < ApplicationController
 
   def random_menu(jenre = "")
     @random_menu = current_user.menus.find(params[:id])
-    if judge_extence_junre_menus(jenre, @random_menu)
+    if judge_extence_junre_menus(jenre, @random_menu) == false
       redirect_to decide_menus_path
     end
   end

--- a/app/controllers/decide_menus_controller.rb
+++ b/app/controllers/decide_menus_controller.rb
@@ -17,13 +17,14 @@ class DecideMenusController < ApplicationController
   end
 
   def judge_extence_junre_menus(jenre, random_menu)
-    puts random_menu
     if random_menu.blank? && jenre != ""
       flash[:alert] = "#{jenre}は登録されていません"
-      redirect_to decide_menus_path
+      return false
+      # redirect_to decide_menus_path
     elsif random_menu.blank? && jenre = ""
       flash[:alert] = "ジャンルがあるメニューを登録してください"
-      redirect_to decide_menus_path
+      return false
+      # redirect_to decide_menus_path
     end
   end
 

--- a/app/controllers/decide_menus_controller.rb
+++ b/app/controllers/decide_menus_controller.rb
@@ -11,20 +11,22 @@ class DecideMenusController < ApplicationController
     @eating_out_menu_id = current_user.menus.where(genre: '外食').order("RAND()").first
   end
 
-  def random_menu
+  def random_menu(jenre)
     @random_menu = current_user.menus.find(params[:id])
-    judge_extence_junre_menus("", @random_menu)
+    if judge_extence_junre_menus(jenre, @random_menu) == false
+      redirect_to decide_menus_path
+    end
   end
 
   def judge_extence_junre_menus(jenre, random_menu)
     if random_menu.blank? && jenre != ""
       flash[:alert] = "#{jenre}は登録されていません"
       return false
-      # redirect_to decide_menus_path
-    elsif random_menu.blank? && jenre = ""
+    elsif random_menu.blank? && jenre == ""
       flash[:alert] = "ジャンルがあるメニューを登録してください"
       return false
-      # redirect_to decide_menus_path
+    else
+      return true
     end
   end
 

--- a/app/controllers/decide_menus_controller.rb
+++ b/app/controllers/decide_menus_controller.rb
@@ -1,6 +1,14 @@
 class DecideMenusController < ApplicationController
 
   def index
+    @random_menu_id = current_user.menus.order("RAND()").first
+    @staple_food_menu_id = current_user.menus.where(genre: '主食').order("RAND()").first
+    @main_dish_menu_id = current_user.menus.where(genre: '主菜').order("RAND()").first
+    @vegetable_menu_id = current_user.menus.where(genre: '野菜').order("RAND()").first
+    @one_item_menu_id = current_user.menus.where(genre: '一品もの').order("RAND()").first
+    @dessert_menu_id = current_user.menus.where(genre: 'デザート').order("RAND()").first
+    @other_menu_id = current_user.menus.where(genre: 'その他').order("RAND()").first
+    @eating_out_menu_id = current_user.menus.where(genre: '外食').order("RAND()").first
   end
 
   def random_menu

--- a/app/controllers/menu_histories_controller.rb
+++ b/app/controllers/menu_histories_controller.rb
@@ -7,6 +7,12 @@ class MenuHistoriesController < ApplicationController
   end
 
   def create
+    @menu_history = MenuHistory.new(menu_history_params)
+    if @menu_history.save
+      redirect_to root_path
+    else
+      render :new
+    end
   end
 
   def edit
@@ -16,6 +22,12 @@ class MenuHistoriesController < ApplicationController
   end
 
   def delete
+  end
+
+  private
+
+  def menu_history_params
+    params.require(:menu_history).permit(:menu_id).merge(user_id: current_user.id, eating_date: Time.new)
   end
 
 end

--- a/app/views/decide_menus/index.html.haml
+++ b/app/views/decide_menus/index.html.haml
@@ -4,7 +4,7 @@
     %h3.ui.red.message{style: "margin-top: 30px; color: red;"}= flash[:alert]
   - else
     %h3{style: "margin-top: 30px"} どのジャンルから選ぶ？
-  = link_to "ランダム", random_menu_decide_menus_path, class: "fluid ui gray big button"
+  = link_to "ランダム", random_menu_decide_menus_path(@random_menu_id), class: "fluid ui gray big button"
   = link_to "主食", random_menu_decide_menus_path(@staple_food_menu_id), class: "fluid ui yellow big button", style: "margin-top: 40px"
   = link_to "主菜", random_menu_decide_menus_path(@main_dish_menu_id), class: "fluid ui red big button", style: "margin-top: 40px"
   = link_to "野菜", random_menu_decide_menus_path(@vegetable_menu_id), class: "fluid ui green big button", style: "margin-top: 40px"

--- a/app/views/decide_menus/index.html.haml
+++ b/app/views/decide_menus/index.html.haml
@@ -5,10 +5,10 @@
   - else
     %h3{style: "margin-top: 30px"} どのジャンルから選ぶ？
   = link_to "ランダム", random_menu_decide_menus_path, class: "fluid ui gray big button"
-  = link_to "主食", staple_food_menu_decide_menus_path, class: "fluid ui yellow big button", style: "margin-top: 40px"
-  = link_to "主菜", main_dish_menu_decide_menus_path, class: "fluid ui red big button", style: "margin-top: 40px"
-  = link_to "野菜", vegetable_menu_decide_menus_path, class: "fluid ui green big button", style: "margin-top: 40px"
-  = link_to "一品もの", one_item_menu_decide_menus_path, class: "fluid ui orange big button", style: "margin-top: 40px"
-  = link_to "デザート", dessert_menu_decide_menus_path, class: "fluid ui pink big button", style: "margin-top: 40px"
-  = link_to "その他", other_menu_decide_menus_path, class: "fluid ui purple big button", style: "margin-top: 40px"
-  = link_to "外食", eating_out_decide_menus_path, class: "fluid ui brown big button", style: "margin-top: 40px; margin-bottom: 40px;"
+  = link_to "主食", random_menu_decide_menus_path(@staple_food_menu_id), class: "fluid ui yellow big button", style: "margin-top: 40px"
+  = link_to "主菜", random_menu_decide_menus_path(@main_dish_menu_id), class: "fluid ui red big button", style: "margin-top: 40px"
+  = link_to "野菜", random_menu_decide_menus_path(@vegetable_menu_id), class: "fluid ui green big button", style: "margin-top: 40px"
+  = link_to "一品もの", random_menu_decide_menus_path(@one_item_menu_id), class: "fluid ui orange big button", style: "margin-top: 40px"
+  = link_to "デザート", random_menu_decide_menus_path(@dessert_menu_id), class: "fluid ui pink big button", style: "margin-top: 40px"
+  = link_to "その他", random_menu_decide_menus_path(@other_menu_id), class: "fluid ui purple big button", style: "margin-top: 40px"
+  = link_to "外食", random_menu_decide_menus_path(@eating_out_menu_id), class: "fluid ui brown big button", style: "margin-top: 40px; margin-bottom: 40px;"

--- a/app/views/decide_menus/index.html.haml
+++ b/app/views/decide_menus/index.html.haml
@@ -1,14 +1,11 @@
 = render "shared/header"
 .ui.text.container.center.aligned.grid
-  - if flash[:alert]
+  - if flash[:alert] # ジャンルがないときはエラー
     %h3.ui.red.message{style: "margin-top: 30px; color: red;"}= flash[:alert]
   - else
     %h3{style: "margin-top: 30px"} どのジャンルから選ぶ？
-  = link_to "ランダム", random_menu_decide_menu_path(@random_menu_id), class: "fluid ui gray big button"
-  -# = link_to "主食", random_menu_decide_menu_path(@staple_food_menu_id), class: "fluid ui yellow big button", style: "margin-top: 40px"
-  -# = link_to "主菜", random_menu_decide_menu_path(@main_dish_menu_id), class: "fluid ui red big button", style: "margin-top: 40px"
-  -# = link_to "野菜", random_menu_decide_menu_path(@vegetable_menu_id), class: "fluid ui green big button", style: "margin-top: 40px"
-  -# = link_to "一品もの", random_menu_decide_menu_path(@one_item_menu_id), class: "fluid ui orange big button", style: "margin-top: 40px"
-  -# = link_to "デザート", random_menu_decide_menu_path(@dessert_menu_id), class: "fluid ui pink big button", style: "margin-top: 40px"
-  -# = link_to "その他", random_menu_decide_menu_path(@other_menu_id), class: "fluid ui purple big button", style: "margin-top: 40px"
-  -# = link_to "外食", random_menu_decide_menu_path(@eating_out_menu_id), class: "fluid ui brown big button", style: "margin-top: 40px; margin-bottom: 40px;"
+  - @decide_menus.each_with_index do |menu, i|
+    - if i == 0 && menu.present? # 1回目の処理は全てのランダムのメニューを取得するため除外
+      = link_to "ランダム", random_menu_decide_menu_path(menu.id), class: "fluid ui gray big button"
+    - elsif menu.present? # ジャンルがあればボタン表示
+      = link_to menu.genre, random_menu_decide_menu_path(menu.id), class: "fluid ui gray big button", style: "margin-top: 40px"

--- a/app/views/decide_menus/index.html.haml
+++ b/app/views/decide_menus/index.html.haml
@@ -4,11 +4,11 @@
     %h3.ui.red.message{style: "margin-top: 30px; color: red;"}= flash[:alert]
   - else
     %h3{style: "margin-top: 30px"} どのジャンルから選ぶ？
-  = link_to "ランダム", random_menu_decide_menus_path(@random_menu_id), class: "fluid ui gray big button"
-  = link_to "主食", random_menu_decide_menus_path(@staple_food_menu_id), class: "fluid ui yellow big button", style: "margin-top: 40px"
-  = link_to "主菜", random_menu_decide_menus_path(@main_dish_menu_id), class: "fluid ui red big button", style: "margin-top: 40px"
-  = link_to "野菜", random_menu_decide_menus_path(@vegetable_menu_id), class: "fluid ui green big button", style: "margin-top: 40px"
-  = link_to "一品もの", random_menu_decide_menus_path(@one_item_menu_id), class: "fluid ui orange big button", style: "margin-top: 40px"
-  = link_to "デザート", random_menu_decide_menus_path(@dessert_menu_id), class: "fluid ui pink big button", style: "margin-top: 40px"
-  = link_to "その他", random_menu_decide_menus_path(@other_menu_id), class: "fluid ui purple big button", style: "margin-top: 40px"
-  = link_to "外食", random_menu_decide_menus_path(@eating_out_menu_id), class: "fluid ui brown big button", style: "margin-top: 40px; margin-bottom: 40px;"
+  = link_to "ランダム", random_menu_decide_menu_path(@random_menu_id), class: "fluid ui gray big button"
+  -# = link_to "主食", random_menu_decide_menu_path(@staple_food_menu_id), class: "fluid ui yellow big button", style: "margin-top: 40px"
+  -# = link_to "主菜", random_menu_decide_menu_path(@main_dish_menu_id), class: "fluid ui red big button", style: "margin-top: 40px"
+  -# = link_to "野菜", random_menu_decide_menu_path(@vegetable_menu_id), class: "fluid ui green big button", style: "margin-top: 40px"
+  -# = link_to "一品もの", random_menu_decide_menu_path(@one_item_menu_id), class: "fluid ui orange big button", style: "margin-top: 40px"
+  -# = link_to "デザート", random_menu_decide_menu_path(@dessert_menu_id), class: "fluid ui pink big button", style: "margin-top: 40px"
+  -# = link_to "その他", random_menu_decide_menu_path(@other_menu_id), class: "fluid ui purple big button", style: "margin-top: 40px"
+  -# = link_to "外食", random_menu_decide_menu_path(@eating_out_menu_id), class: "fluid ui brown big button", style: "margin-top: 40px; margin-bottom: 40px;"

--- a/app/views/shared/_decide_menu.html.haml
+++ b/app/views/shared/_decide_menu.html.haml
@@ -25,7 +25,7 @@
         %p= @random_menu.text
   .ui.text.container.center.aligned.grid{style: "margin-top: 40px;"}
     = link_to "今日はこれにする！", menu_histories_path, class: "fluid ui red big button", style: "margin-bottom: 40px;", method: "POST"
-    = link_to "この気分じゃない", random_menu_decide_menus_path, class: "fluid ui orange big button", style: "margin-bottom: 40px;"
+    = link_to "この気分じゃない", random_menu_decide_menu_path(@next_random_menu.id), class: "fluid ui orange big button", style: "margin-bottom: 40px;"
 
 :css
   .slider img {

--- a/app/views/shared/_decide_menu.html.haml
+++ b/app/views/shared/_decide_menu.html.haml
@@ -24,6 +24,7 @@
         .ui.dividing.header メモ
         %p= @random_menu.text
   .ui.text.container.center.aligned.grid{style: "margin-top: 40px;"}
+    = link_to "今日はこれにする！", menu_histories_path, class: "fluid ui red big button", style: "margin-bottom: 40px;", method: "POST"
     = link_to "この気分じゃない", random_menu_decide_menus_path, class: "fluid ui orange big button", style: "margin-bottom: 40px;"
 
 :css

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,15 +13,8 @@ Rails.application.routes.draw do
   end
   resources :menu_histories, only: [:index, :show, :create, :edit, :update, :delete]
   resources :decide_menus do
-    collection do
-      get :staple_food_menu
+    member do
       get :random_menu
-      get :main_dish_menu
-      get :vegetable_menu
-      get :one_item_menu
-      get :dessert_menu
-      get :other_menu
-      get :eating_out
     end
   end
 end


### PR DESCRIPTION
## 何を行ったか
- メニュー履歴作成機能
## なぜ行ったか
- 1ヶ月前のメニューと被らないようにし、メニューをシャッフルできる機能を作成するため
## どのように行ったか
- ランダムにメニューを取得するバックエンドの処理で、パラメーターにidを渡し、メニューを取得するように変更。