### PR TITLE
メニュー詳細画面から履歴登録

### DIFF
--- a/app/controllers/decide_menus_controller.rb
+++ b/app/controllers/decide_menus_controller.rb
@@ -13,40 +13,40 @@ class DecideMenusController < ApplicationController
   end
 
   def random_menu
-    @menu_history = MenuHistory.new
     @random_menu = current_user.menus.find(params[:id])
     genre = ""
+    if judge_extence_junre_menus(genre, @random_menu) == false # ジャンルのメニューが無い場合
+      redirect_to decide_menus_path # エラーを出し、画面遷移しない
+    end
+    @menu_history = MenuHistory.new
     @next_random_menu = current_user.menus.order("RAND()").first
     # 日付が今日の履歴データが存在する場合、updateするためのformを作成するためにview側でhiddenを表示
-    today_menu_history_array = MenuHistory.where("eating_date >= ?",  Date.today)
-    if (today_menu_history_array)
+    today_menu_history_array = MenuHistory.where("eating_date >= ?", Date.today)
+    if today_menu_history_array.present?
       today_menu_history = today_menu_history_array[0]
       @menu_ids = []
       today_menu_history.menu_menu_histories_connections.each do |connection|
         @menu_ids << connection.menu_id
       end
-    end
-    if judge_extence_junre_menus(genre, @random_menu) == false # ジャンルのメニューが無い場合
-      redirect_to decide_menus_path
     end
   end
 
   def random_genre_menu
-    @menu_history = MenuHistory.new
     @random_menu = current_user.menus.find(params[:id])
     genre = @random_menu.genre
+    if judge_extence_junre_menus(genre, @random_menu) == false # ジャンルのメニューが無い場合
+      redirect_to decide_menus_path # エラーを出し、画面遷移しない
+    end
+    @menu_history = MenuHistory.new
     @next_random_menu = current_user.menus.where(genre: genre).order("RAND()").first
     # 日付が今日の履歴データが存在する場合、updateするためのformを作成するためにview側でhiddenを表示
-    today_menu_history_array = MenuHistory.where("eating_date >= ?",  Date.today)
-    if (today_menu_history_array)
+    today_menu_history_array = MenuHistory.where("eating_date >= ?", Date.today)
+    if today_menu_history_array.present?
       today_menu_history = today_menu_history_array[0]
       @menu_ids = []
       today_menu_history.menu_menu_histories_connections.each do |connection|
         @menu_ids << connection.menu_id
       end
-    end
-    if judge_extence_junre_menus(genre, @random_menu) == false # ジャンルのメニューが無い場合
-      redirect_to decide_menus_path
     end
   end
 

--- a/app/controllers/menu_histories_controller.rb
+++ b/app/controllers/menu_histories_controller.rb
@@ -8,9 +8,9 @@ class MenuHistoriesController < ApplicationController
   end
 
   def create
-    today_menu_history_array = MenuHistory.where("eating_date >= ?",  Date.today) # 今日の日付開始より大きい日付（今日登録したデータ）
+    today_menu_history_array = MenuHistory.where("eating_date >= ?", Date.today) # 今日の日付開始より大きい日付（今日登録したデータ）
     # 今日の日付分のデータが既にある場合、今日の日付に紐づくメニューを更新
-    if (today_menu_history_array)
+    if today_menu_history_array.present?
       today_menu_history = today_menu_history_array[0]
       if today_menu_history.update(menu_history_params)
         redirect_to root_path

--- a/app/controllers/menu_histories_controller.rb
+++ b/app/controllers/menu_histories_controller.rb
@@ -2,7 +2,6 @@ class MenuHistoriesController < ApplicationController
   def index
     @menu_histories = current_user.menu_histories.order(eating_date: "DESC").page(params[:page]).per(5)
     today_menu_history = MenuHistory.where("eating_date >= ?",  Date.today)
-    puts today_menu_history[0].eating_date
   end
 
   def show

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -23,11 +23,21 @@ class MenusController < ApplicationController
 
   def show
     @menu = Menu.find(params[:id])
+    @menu_history = MenuHistory.new
+    today_menu_history_array = MenuHistory.where("eating_date >= ?", Date.today)
+    # 日付が今日の履歴データが存在する場合、menu＿historyをupdateするためのformを作成するためにview側でhiddenを表示
+    if today_menu_history_array.present?
+      today_menu_history = today_menu_history_array[0]
+      @menu_ids = []
+      today_menu_history.menu_menu_histories_connections.each do |connection|
+        @menu_ids << connection.menu_id
+      end
+    end
   end
 
   def edit
     @menu = Menu.find(params[:id])
-    # 配列の数が4未満なら空の配列を入れて要素を４個に保管するする
+    # 配列の数が4未満なら空の配列を入れて要素を４個に保管する
     @no_menu_count_array = [] # 画像がない枚数を配列に格納
     @noimage_form_count = 4 - @menu.menu_images.count
     @noimage_form_count.times do |i|

--- a/app/views/menus/show.html.haml
+++ b/app/views/menus/show.html.haml
@@ -28,6 +28,14 @@
         - if @menu.text.present?
           .ui.dividing.header メモ
           %p= @menu.text
+  = form_with model: @menu_history, class: "ui text container center aligned grid", style: "width: 100%;", local: true do |f|
+    -# 中間テーブルに保存
+    %input{type: 'hidden', name: 'menu_history[menu_ids][]', value: @menu.id}
+    -# 今日に作成したメニュー履歴が作成されている場合、中間テーブルのみをupdateするためのmenu_idをinput要素で表示
+    - if @menu_ids.present?
+      - @menu_ids.each do |menu_id|
+        %input{type: 'hidden', name: 'menu_history[menu_ids][]', value: menu_id}
+    = f.submit "今からこれを食べる！", class: "fluid ui green big button", style: "margin-bottom: 40px;"
 
 :css
   .slider img {


### PR DESCRIPTION
## What
- メニュー履歴を一覧からの詳細画面からも登録できるように機能を拡張
## Why
- 一覧画面から好きなメニューを選択し、履歴として登録できるようにするため
## How
- menu_showのviewに、履歴を作成できるボタンを追加
- decide_menu.controllerでの処理に不具合が見られたため、修正