### PR TITLE
メニュー履歴編集機能（JavaScriptで実装）

### DIFF
--- a/app/controllers/menu_histories_controller.rb
+++ b/app/controllers/menu_histories_controller.rb
@@ -25,7 +25,23 @@ class MenuHistoriesController < ApplicationController
     end
   end
 
-  def delete
+  def update
+    menu_history = MenuHistory.find(params[:id])
+    # 全部削除されていた場合は履歴自体を削除
+    if params[:menu_ids].blank?
+      # Menuhistoryを削除
+      if menu_history.destroy
+        redirect_to menu_histories_path
+      else
+        render menu_histories_path
+      end
+    else
+      if menu_history.update(menu_history_params)
+        redirect_to menu_histories_url, alert: 'エラーが発生しました'
+      else
+        render menu_histories_path
+      end
+    end
   end
 
   private

--- a/app/controllers/menu_histories_controller.rb
+++ b/app/controllers/menu_histories_controller.rb
@@ -4,9 +4,6 @@ class MenuHistoriesController < ApplicationController
     today_menu_history = MenuHistory.where("eating_date >= ?",  Date.today)
   end
 
-  def show
-  end
-
   def create
     today_menu_history_array = MenuHistory.where("eating_date >= ?", Date.today) # 今日の日付開始より大きい日付（今日登録したデータ）
     # 今日の日付分のデータが既にある場合、今日の日付に紐づくメニューを更新
@@ -26,12 +23,6 @@ class MenuHistoriesController < ApplicationController
         render :new
       end
     end
-  end
-
-  def edit
-  end
-
-  def update
   end
 
   def delete

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -18,11 +18,9 @@ jQuery(document).on('turbolinks:load', function(){
   $('.special.cards .image').dimmer({
     on: 'hover'
   });
-  $('#right-btn').click(function(){
-    $('.shape').shape('flip right');
-  });
-  $('#left-btn').click(function(){
-    $('.shape').shape('flip left');
+  $('.ui.dividing.header.menu-history-edit') // メニュー履歴の編集表示
+   .popup({
+    on: 'hover'
   });
 })
 

--- a/app/models/menu_history.rb
+++ b/app/models/menu_history.rb
@@ -1,5 +1,5 @@
 class MenuHistory < ApplicationRecord
   belongs_to :user
-  has_many :menu_menu_histories_connections
+  has_many :menu_menu_histories_connections, dependent: :destroy
   has_many :menu, through: :menu_menu_histories_connections
 end

--- a/app/models/menu_menu_histories_connection.rb
+++ b/app/models/menu_menu_histories_connection.rb
@@ -1,4 +1,4 @@
 class MenuMenuHistoriesConnection < ApplicationRecord
-  belongs_to :menu
-  belongs_to :menu_history
+  belongs_to :menu, optional: true
+  belongs_to :menu_history, optional: true
 end

--- a/app/views/menu_histories/edit.html.haml
+++ b/app/views/menu_histories/edit.html.haml
@@ -1,2 +1,0 @@
-%h1 MenuHistories#edit
-%p Find me in app/views/menu_histories/edit.html.haml

--- a/app/views/menu_histories/index.html.haml
+++ b/app/views/menu_histories/index.html.haml
@@ -7,28 +7,30 @@
       %i.calendar.icon
       %input{type: "text", name: "date", placeholder: "日付"}
 - @menu_histories.each do |menu_history|
-  %div{class: "ui", id: menu_history.id, style: "margin: 30px 10px"}
-    .ui.stackable.column.container.grid{style: "padding-top: 30px;"}
-      .column
-        .ui.dividing.header.menu-history-edit{ data: { content: "編集する"} }
-          %a{style: "cursor: pointer;", onclick: "editMenuHistory(event)", data: { historyid: menu_history.id} }
-            = menu_history.eating_date.strftime("%Y年 %m月 %d日")
-    .ui.menu-history
-      .ui.four.stackable.cards{style: "margin: 10px 10px;"}
-        - menu_history.menu.each do |menu|
-          .orange.card
-            = link_to menu_path(menu.id), {class: "ui image"} do
-              = image_tag menu.menu_images[0].image.url, class: "ui medium image change-image", style: "height: 230px;"
-            .content
-              = link_to menu_path(menu.id), {class: "header"} do
-                = menu.name
-              .ui.red.ribbon.label
-                = menu.genre
-              .meta
-              .description{style: "font-size: 12px;"}
-                - if menu.text.present?
-                  = link_to menu_path(menu.id), {class: "text"} do
-                    = truncate(menu.text, length: 150)
+  = form_with model: menu_history, local: true do |form|
+    %div{class: "ui", id: menu_history.id, style: "margin: 30px 10px"}
+      .ui.stackable.column.container.grid{style: "padding-top: 30px;"}
+        .column
+          .ui.dividing.header.menu-history-edit{ data: { content: "編集する"} }
+            %a{style: "cursor: pointer;", onclick: "editMenuHistory(event)", data: { historyid: menu_history.id} }
+              = menu_history.eating_date.strftime("%Y年 %m月 %d日")
+      .ui.menu-history
+        .ui.four.stackable.cards{style: "margin: 10px 10px;"}
+          - menu_history.menu.each do |menu|
+            %div{class: "orange card", id: menu.id}
+              = link_to menu_path(menu.id), {class: "ui image"} do
+                = image_tag menu.menu_images[0].image.url, class: "ui medium image change-image", style: "height: 230px;"
+              .content
+                = link_to menu_path(menu.id), {class: "header"} do
+                  = menu.name
+                .ui.red.ribbon.label
+                  = menu.genre
+                .meta
+                .description{style: "font-size: 12px;"}
+                  - if menu.text.present?
+                    = link_to menu_path(menu.id), {class: "text"} do
+                      = truncate(menu.text, length: 150)
+              %input{name: "menu_history[menu_ids][]", type: "hidden", value: menu.id}
 
 -# ページネーション
 .ui.column.centered.grid{style: "margin-top: 20px; padding-bottom: 40px;"}
@@ -50,18 +52,51 @@
 
   // メニュー履歴編集
   function editMenuHistory(event){
-    // 他のメニュー履歴を編集している場合はセグメント・チェックボックス・削除ボタンの削除
+    // 他のメニュー履歴を編集している場合はセグメント・削除ボタン・更新ボタンの削除
     if(document.querySelector('.segment')) {
       // id: segment のみ削除
       let elm = document.querySelector('.segment')
       elm.classList.remove("placeholder");
       elm.classList.remove("segment");
+      // 削除ボタンの削除
+      let dlete_btns = elm.getElementsByClassName('delete-button');
+      let dlete_btns_array = Array.from(dlete_btns);
+      for (let i = 0; i < dlete_btns_array.length; ++i) {
+        let target_dlete_btn = dlete_btns_array[i];
+        target_dlete_btn.remove();
+      }
     }
 
     // セグメント内にメニュー履歴をいれる
-    let base_id = event.target.dataset.historyid;
-    let target_history = document.getElementById(base_id);
-    target_history.classList.add('placeholder');
+    let menu_history_id = event.target.dataset.historyid;
+    let target_history = document.getElementById(menu_history_id);
     target_history.classList.add('segment');
-    // 編集しているメニュー履歴のセグメント要素を作成
+
+    // 削除ボタン追加
+    let checkbox_targets = target_history.getElementsByClassName('card');
+    checkbox_targets_array = Array.from(checkbox_targets);
+
+    for (let i = 0; i < checkbox_targets_array.length; ++i) {
+      let checkbox_target = checkbox_targets_array[i];
+      let menu_id = checkbox_target.id;
+      let checkbox =`<div class="ui bottom attached red button delete-button" style="width: 100%;" onclick="menuDestroy(event, ${menu_id})"> 削除 </div>
+                    `
+      checkbox_target.insertAdjacentHTML("beforeend", checkbox);
+    }
+
+    // 削除ボタン追加
+    let destroy_button = `
+    <div class="ui center aligned grid">
+      <div class="eight wide column">
+        <input type="submit" name="commit" class="ui green button">
+      </div>
+    </div>
+    `
+    target_history.insertAdjacentHTML("beforeend", destroy_button);
+  }
+
+  // 履歴からメニュー削除
+  function menuDestroy(event, menu_id){
+    let target_menu = document.getElementById(menu_id);
+    target_menu.remove();
   }

--- a/app/views/menu_histories/index.html.haml
+++ b/app/views/menu_histories/index.html.haml
@@ -8,7 +8,7 @@
       %input{type: "text", name: "date", placeholder: "日付"}
 - @menu_histories.each do |menu_history|
   = form_with model: menu_history, local: true do |form|
-    %div{class: "ui", id: menu_history.id, style: "margin: 30px 10px"}
+    %div{class: "ui", id: "menu-history-#{menu_history.id}", style: "margin: 30px 10px"}
       .ui.stackable.column.container.grid{style: "padding-top: 30px;"}
         .column
           .ui.dividing.header.menu-history-edit{ data: { content: "編集する"} }
@@ -17,7 +17,7 @@
       .ui.menu-history
         .ui.four.stackable.cards{style: "margin: 10px 10px;"}
           - menu_history.menu.each do |menu|
-            %div{class: "orange card", id: menu.id}
+            %div{class: "orange card", id: "menu-#{menu.id}"}
               = link_to menu_path(menu.id), {class: "ui image"} do
                 = image_tag menu.menu_images[0].image.url, class: "ui medium image change-image", style: "height: 230px;"
               .content
@@ -72,7 +72,7 @@
 
     // セグメント内にメニュー履歴をいれる
     let menu_history_id = event.target.dataset.historyid;
-    let target_history = document.getElementById(menu_history_id);
+    let target_history = document.getElementById('menu-history-' + menu_history_id);
     target_history.classList.add('segment');
 
     // 削除ボタン追加
@@ -100,6 +100,6 @@
 
   // 履歴からメニュー削除
   function menuDestroy(event, menu_id){
-    let target_menu = document.getElementById(menu_id);
+    let target_menu = document.getElementById('menu-' + menu_id);
     target_menu.remove();
   }

--- a/app/views/menu_histories/index.html.haml
+++ b/app/views/menu_histories/index.html.haml
@@ -7,26 +7,28 @@
       %i.calendar.icon
       %input{type: "text", name: "date", placeholder: "日付"}
 - @menu_histories.each do |menu_history|
-  .ui.stackable.column.container.grid{style: "padding-top: 30px;"}
-    .column
-      .ui.dividing.header.menu-history-edit{ data: { content: "編集する"} }
-        %a{style: "cursor: pointer;"}
-          = menu_history.eating_date.strftime("%Y年 %m月 %d日")
-  .ui.four.stackable.cards{style: "margin: 10px 10px;"}
-    - menu_history.menu.each do |menu|
-      .orange.card
-        = link_to menu_path(menu.id), {class: "ui image"} do
-          = image_tag menu.menu_images[0].image.url, class: "ui medium image change-image", style: "height: 230px;"
-        .content
-          = link_to menu_path(menu.id), {class: "header"} do
-            = menu.name
-          .ui.red.ribbon.label
-            = menu.genre
-          .meta
-          .description{style: "font-size: 12px;"}
-            - if menu.text.present?
-              = link_to menu_path(menu.id), {class: "text"} do
-                = truncate(menu.text, length: 150)
+  %div{class: "ui", id: menu_history.id, style: "margin: 30px 10px"}
+    .ui.stackable.column.container.grid{style: "padding-top: 30px;"}
+      .column
+        .ui.dividing.header.menu-history-edit{ data: { content: "編集する"} }
+          %a{style: "cursor: pointer;", onclick: "editMenuHistory(event)", data: { historyid: menu_history.id} }
+            = menu_history.eating_date.strftime("%Y年 %m月 %d日")
+    .ui.menu-history
+      .ui.four.stackable.cards{style: "margin: 10px 10px;"}
+        - menu_history.menu.each do |menu|
+          .orange.card
+            = link_to menu_path(menu.id), {class: "ui image"} do
+              = image_tag menu.menu_images[0].image.url, class: "ui medium image change-image", style: "height: 230px;"
+            .content
+              = link_to menu_path(menu.id), {class: "header"} do
+                = menu.name
+              .ui.red.ribbon.label
+                = menu.genre
+              .meta
+              .description{style: "font-size: 12px;"}
+                - if menu.text.present?
+                  = link_to menu_path(menu.id), {class: "text"} do
+                    = truncate(menu.text, length: 150)
 
 -# ページネーション
 .ui.column.centered.grid{style: "margin-top: 20px; padding-bottom: 40px;"}
@@ -45,3 +47,21 @@
       }
     }
   });
+
+  // メニュー履歴編集
+  function editMenuHistory(event){
+    // 他のメニュー履歴を編集している場合はセグメント・チェックボックス・削除ボタンの削除
+    if(document.querySelector('.segment')) {
+      // id: segment のみ削除
+      let elm = document.querySelector('.segment')
+      elm.classList.remove("placeholder");
+      elm.classList.remove("segment");
+    }
+
+    // セグメント内にメニュー履歴をいれる
+    let base_id = event.target.dataset.historyid;
+    let target_history = document.getElementById(base_id);
+    target_history.classList.add('placeholder');
+    target_history.classList.add('segment');
+    // 編集しているメニュー履歴のセグメント要素を作成
+  }

--- a/app/views/menu_histories/index.html.haml
+++ b/app/views/menu_histories/index.html.haml
@@ -65,6 +65,9 @@
         let target_dlete_btn = dlete_btns_array[i];
         target_dlete_btn.remove();
       }
+      // 更新ボタンの削除
+      let update_btn = document.getElementById('update-btn');
+      update_btn.remove();
     }
 
     // セグメント内にメニュー履歴をいれる
@@ -84,15 +87,15 @@
       checkbox_target.insertAdjacentHTML("beforeend", checkbox);
     }
 
-    // 削除ボタン追加
-    let destroy_button = `
-    <div class="ui center aligned grid">
+    // 更新ボタン追加
+    let update_btn = `
+    <div class="ui center aligned grid" id="update-btn">
       <div class="eight wide column">
-        <input type="submit" name="commit" class="ui green button">
+        <input type="submit" name="commit" class="ui green button" value="更新">
       </div>
     </div>
     `
-    target_history.insertAdjacentHTML("beforeend", destroy_button);
+    target_history.insertAdjacentHTML("beforeend", update_btn);
   }
 
   // 履歴からメニュー削除

--- a/app/views/menu_histories/index.html.haml
+++ b/app/views/menu_histories/index.html.haml
@@ -1,4 +1,7 @@
 = render "shared/header"
+.ui.text.container.center.aligned.grid
+  - if flash[:alert] # ジャンルがないときはエラー
+    %h3.ui.red.message{style: "margin-top: 30px; color: red;"}= flash[:alert]
 .ui.text.container.center.aligned.grid{style: "margin-top: 30px"}
   %h2 日付指定検索
   .field.ui.calendar.required
@@ -17,7 +20,7 @@
       .ui.menu-history
         .ui.four.stackable.cards{style: "margin: 10px 10px;"}
           - menu_history.menu.each do |menu|
-            %div{class: "orange card", id: "menu-#{menu.id}"}
+            %div{class: "orange card", id: "menu-#{menu_history.id}-#{menu.id}"}
               = link_to menu_path(menu.id), {class: "ui image"} do
                 = image_tag menu.menu_images[0].image.url, class: "ui medium image change-image", style: "height: 230px;"
               .content
@@ -82,7 +85,7 @@
     for (let i = 0; i < checkbox_targets_array.length; ++i) {
       let checkbox_target = checkbox_targets_array[i];
       let menu_id = checkbox_target.id;
-      let checkbox =`<div class="ui bottom attached red button delete-button" style="width: 100%;" onclick="menuDestroy(event, ${menu_id})"> 削除 </div>
+      let checkbox =`<div class="ui bottom attached red button delete-button" style="width: 100%;" onclick="menuDestroy(event, '${menu_id}')"> 削除 </div>
                     `
       checkbox_target.insertAdjacentHTML("beforeend", checkbox);
     }
@@ -100,6 +103,7 @@
 
   // 履歴からメニュー削除
   function menuDestroy(event, menu_id){
-    let target_menu = document.getElementById('menu-' + menu_id);
-    target_menu.remove();
+    let target_destroy_menu = document.getElementById(menu_id);
+    console.log(target_destroy_menu);
+    target_destroy_menu.remove();
   }

--- a/app/views/menu_histories/index.html.haml
+++ b/app/views/menu_histories/index.html.haml
@@ -9,8 +9,9 @@
 - @menu_histories.each do |menu_history|
   .ui.stackable.column.container.grid{style: "padding-top: 30px;"}
     .column
-      .ui.dividing.header
-        = menu_history.eating_date.strftime("%Y年 %m月 %d日")
+      .ui.dividing.header.menu-history-edit{ data: { content: "編集する"} }
+        %a{style: "cursor: pointer;"}
+          = menu_history.eating_date.strftime("%Y年 %m月 %d日")
   .ui.four.stackable.cards{style: "margin: 10px 10px;"}
     - menu_history.menu.each do |menu|
       .orange.card
@@ -21,8 +22,6 @@
             = menu.name
           .ui.red.ribbon.label
             = menu.genre
-          -# .ui.blue.tag.label -#ラベルを複数実施する時に使用
-          -#   = menu.genre
           .meta
           .description{style: "font-size: 12px;"}
             - if menu.text.present?
@@ -34,6 +33,7 @@
   = paginate @menus
 
 :javascript
+  // カレンダーの表示
   $('.ui.calendar').calendar({
     type: 'date',
     formatter: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
       get :menu_search
     end
   end
-  resources :menu_histories, only: [:index, :show, :create, :edit, :update, :delete]
+  resources :menu_histories, only: [:index, :show, :create, :update]
   resources :decide_menus do
     member do
       get :random_menu


### PR DESCRIPTION
# 何を行ったか
- JavaScriptを使い、メニュー履歴の編集・削除機能を実装。
# なぜ行ったか
- メニュー履歴が編集できなく、登録することしかできなく、使い勝手が悪いため。
# どのように行ったか
- JavaScriptを使い、フロント内でメニュー履歴削除項目を指定し削除できるよう設計。